### PR TITLE
Rename TokenStore to sessionStore and add userId support

### DIFF
--- a/src/features/onboarding/services/authService.ts
+++ b/src/features/onboarding/services/authService.ts
@@ -1,5 +1,5 @@
 import { apiPublicJson, apiAuthJson } from '../../../shared/api';
-import { tokenStore } from '../../../types/tokenStore';
+import { sessionStore } from '../../../types/sessionStore';
 import type { LoginRequest, LoginResponse } from '../types';
 
 export const AuthService = {
@@ -7,11 +7,8 @@ export const AuthService = {
   // refresh cookie is managed by the server
   async localLogin(req: LoginRequest) {
     const res = await apiPublicJson<LoginResponse, LoginRequest>(
-      "/auth/local/login", {
-        method: "POST",
-        json: req,
-      });
-      tokenStore.set(res.accessToken);
+      "/auth/local/login", { method: "POST", json: req });
+      sessionStore.init(res.accessToken, res.userId);
       return res;
   },
 
@@ -19,10 +16,9 @@ export const AuthService = {
   // ans remove access token on client
   async logout() {
     try {
-      await apiAuthJson<void>(
-        "/auth/token/logout", { method: "POST" });
+      await apiAuthJson<void>("/auth/token/logout", { method: "POST" });
     } finally {
-      tokenStore.clear();
+      sessionStore.clear();
     }
   }
 };

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -1,8 +1,9 @@
 export type LoginRequest = { 
   email: string;
-  password: string
+  password: string;
 };
 
 export type LoginResponse = {
   accessToken: string;
+  userId: string;
 };

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,7 +1,7 @@
 import { API_BASE_URL } from "../config";
 import type { ProblemDetails } from "../types/http";
 import { ApiError } from "../types/http";
-import { tokenStore } from "../types/tokenStore";
+import { sessionStore } from "../types/sessionStore";
 
 // JSON Request without authentication header 
 // (public, no authentication required)
@@ -18,7 +18,7 @@ export async function apiAuthJson<TRes, TBody = unknown>(
   init?: RequestInit & { json?: TBody },
   retried = false
 ): Promise<TRes> {
-  const token = tokenStore.get();
+  const token = sessionStore.getToken();
   const withAuth: RequestInit = {
     ...init,
     headers: { 
@@ -44,7 +44,7 @@ async function tryRefereshAccessToken() {
   const res = await doFetch("/auth/token/refresh", { method: "POST" });
   await ensureOK(res);
   const data = (await res.json()) as { accessToken: string };
-  tokenStore.set(data.accessToken);
+  sessionStore.updateToken(data.accessToken);
 }
 
 // Low-level fetch with credentials included 

--- a/src/types/sessionStore.ts
+++ b/src/types/sessionStore.ts
@@ -1,0 +1,30 @@
+export const sessionStore = {
+  accessToken: null as string | null,
+  userId: null as string | null,
+
+  init(token: string, id: string) {
+    this.accessToken = token;
+    this.userId = id;
+  },
+
+  updateToken(token: string) {
+    this.accessToken = token;
+  },
+
+  getToken() {
+    return this.accessToken;
+  },
+
+  getUserId() {
+    return this.userId;
+  },
+
+  clear() {
+    this.accessToken = null;
+    this.userId = null;
+  },
+
+  isAuthenticated() {
+    return !!this.accessToken;
+  }
+};

--- a/src/types/tokenStore.ts
+++ b/src/types/tokenStore.ts
@@ -1,7 +1,0 @@
-let accessToken: string | null = null;
-
-export const tokenStore = {
-  get: () => accessToken,
-  set: (t: string | null) => { accessToken = t; },
-  clear: () =>  { accessToken = null; },
-};


### PR DESCRIPTION
This patch would:
- renamed tokenStore to sessionStore to reflect session state responsibility
- Store now manages both accessToken and userId
- added updateToken(), getToken(), getUserId() helpers for clarity
- ensured logout and refresh flows clear or update session correctly