### PR TITLE
Wire ProductsHomePage to productSummaryListLoader 

### DIFF
--- a/src/features/products/components/ProductSummaryListHeader.tsx
+++ b/src/features/products/components/ProductSummaryListHeader.tsx
@@ -1,58 +1,83 @@
 import styles from './styles/ProductSummaryListHeader.module.css';
-import { FiChevronDown } from "react-icons/fi";
+import { useSearchParams } from 'react-router-dom';
 
 type Props = {
-  categoryCode: string;
-  sortBy: string;
-  totalCount: number;
-  onCategoryClick: () => void;
-  onSortClick: () => void;    
+  totalCount: number; 
 };     
 
-const CATEGORY_LABEL: Record<string, string> = {
-  all: "전체",
-  book_stand: "독서대",
-  book_cover: "북커버",
-  book_mark: "북마크",
-  book_storage: "책수납",
-  magnifier: "돋보기",
-  foot_rest: "발받침대",
-  book_perfume: "북퍼퓸",
-  book_light: "북라이트",
-  paper_weight: "문진",
-  reading_note: "독서노트",
-};
-const SORT_LABEL: Record<Props["sortBy"], string> = {
-  createdAt: "최신순",
-  unitPriceAmount: "가격순",
-  averageRating: "평점순",
-  reviewCount: "리뷰순",
-};
+type SortBy = "createdAt" | "unitPriceAmount" | "averageRating" | "reviewCount";
+type Order  = "asc" | "desc";
 
-export default function ProductSummaryListHeader({
-    categoryCode,
-    sortBy,
-    totalCount,
-    onCategoryClick,
-    onSortClick,  
-}: Props) {
-  const categoryLabel = CATEGORY_LABEL[categoryCode] ?? "전체";
-  const sortLabel = SORT_LABEL[sortBy] ?? "최신순";
+const CATEGORY_OPTIONS: Array<{ code: string; label: string }> = [
+  { code: "all",          label: "전체" },
+  { code: "book_stand",   label: "독서대" },
+  { code: "book_cover",   label: "북커버" },
+  { code: "book_mark",    label: "북마크" },
+  { code: "book_storage", label: "책수납" },
+  { code: "magnifier",    label: "돋보기" },
+  { code: "foot_rest",    label: "발받침대" },
+  { code: "book_perfume", label: "북퍼퓸" },
+  { code: "book_light",   label: "북라이트" },
+  { code: "paper_weight", label: "문진" },
+  { code: "reading_note", label: "독서노트" },
+];
+const SORT_OPTIONS: Array<{ key: string; label: string; sortBy: SortBy; order: Order }> = [
+  { key: "createdAt:desc",       label: "최신순",       sortBy: "createdAt",      order: "desc" },
+  { key: "reviewCount:desc",     label: "리뷰많은순",   sortBy: "reviewCount",    order: "desc" },
+  { key: "averageRating:desc",   label: "평점높은순",   sortBy: "averageRating",  order: "desc" },
+  { key: "unitPriceAmount:asc",  label: "가격낮은순",   sortBy: "unitPriceAmount",order: "asc"  },
+  { key: "unitPriceAmount:desc", label: "가격높은순",   sortBy: "unitPriceAmount",order: "desc" },
+];
+
+export default function ProductSummaryListHeader({ totalCount }: Props) {
+  const [ sp, setSp ] = useSearchParams();
+
+  const category = sp.get("category") ?? "all";
+  const sortBy   = (sp.get("sortBy") ?? "createdAt") as SortBy;
+  const order    = (sp.get("order")  ?? "desc") as Order;
+  const currentSortKey = `${sortBy}:${order}`;
+
+  const onChangeCategory = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = new URLSearchParams(sp);
+    next.set("category", e.target.value);
+    next.set("page", "1");
+    setSp(next);
+  };
+  const onChangeSort = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const [sb, ord] = e.target.value.split(":") as [SortBy, Order];
+    const next = new URLSearchParams(sp);
+    next.set("sortBy", sb);
+    next.set("order", ord);
+    next.set("page", "1");
+    setSp(next);
+  };
+
   return (
     <div className={styles['product-summary-list-header']}>
       <div className={styles['header-left']}>
-          <button className={styles['category-trigger']} type="button" onClick={onCategoryClick}>
-            <span className={styles['category-label']}>{categoryLabel}</span>
-            <span className={styles['category-icon']}><FiChevronDown size={14} /></span>
-          </button>
-          <span className={styles['total-count']}>{totalCount}</span>
+        <select
+          className={styles['category-select']}  
+          value={category}
+          onChange={onChangeCategory}
+        >
+          {CATEGORY_OPTIONS.map(opt => (
+            <option key={opt.code} value={opt.code}>{opt.label}</option>
+          ))}
+        </select>
+
+        <span className={styles['total-count']}>{totalCount} 건</span>
       </div>
 
       <div className={styles['header-right']}>
-          <button className={styles['sort-trigger']} type="button" onClick={onSortClick}>
-            <span className={styles['sort-label']}>{sortLabel}</span>
-            <span className={styles['sort-icon']}><FiChevronDown size={14} /></span>
-          </button>
+        <select
+          className={styles['sort-select']}       
+          value={currentSortKey}
+          onChange={onChangeSort}
+        >
+          {SORT_OPTIONS.map(opt => (
+            <option key={opt.key} value={opt.key}>{opt.label}</option>
+          ))}
+        </select>
       </div>
     </div>
   )

--- a/src/features/products/components/ProductSummaryListHeader.tsx
+++ b/src/features/products/components/ProductSummaryListHeader.tsx
@@ -2,20 +2,42 @@ import styles from './styles/ProductSummaryListHeader.module.css';
 import { FiChevronDown } from "react-icons/fi";
 
 type Props = {
-  categoryLabel: string;
-  sortLabel: string;
+  categoryCode: string;
+  sortBy: string;
   totalCount: number;
   onCategoryClick: () => void;
   onSortClick: () => void;    
 };     
 
+const CATEGORY_LABEL: Record<string, string> = {
+  all: "전체",
+  book_stand: "독서대",
+  book_cover: "북커버",
+  book_mark: "북마크",
+  book_storage: "책수납",
+  magnifier: "돋보기",
+  foot_rest: "발받침대",
+  book_perfume: "북퍼퓸",
+  book_light: "북라이트",
+  paper_weight: "문진",
+  reading_note: "독서노트",
+};
+const SORT_LABEL: Record<Props["sortBy"], string> = {
+  createdAt: "최신순",
+  unitPriceAmount: "가격순",
+  averageRating: "평점순",
+  reviewCount: "리뷰순",
+};
+
 export default function ProductSummaryListHeader({
-    categoryLabel,
-    sortLabel,
+    categoryCode,
+    sortBy,
     totalCount,
     onCategoryClick,
     onSortClick,  
 }: Props) {
+  const categoryLabel = CATEGORY_LABEL[categoryCode] ?? "전체";
+  const sortLabel = SORT_LABEL[sortBy] ?? "최신순";
   return (
     <div className={styles['product-summary-list-header']}>
       <div className={styles['header-left']}>

--- a/src/features/products/components/styles/ProductSummaryListHeader.module.css
+++ b/src/features/products/components/styles/ProductSummaryListHeader.module.css
@@ -19,13 +19,6 @@
   align-items: center;
 }
 
-.category-trigger {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 5px;
-}
-
 .total-count {
   color: #8D8D8D;  
   font-size: 11px;
@@ -34,33 +27,21 @@
   line-height: 100%; 
 }
 
-.category-label {
-  color: #000;
-  font-size: 13px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 100%;
-}
-
-.category-icon, .sort-icon {
-  width: 15px;
-  height: 15px;
-  display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid #BDBDBD; border-radius: 100px;
-}
-
-.sort-trigger {
-  display: flex;          
-  align-items: center;
-  gap: 5px;              
-}
-
-.sort-label {
-  color: #000;
-  font-size: 13px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 100%;
+.category-select,
+.sort-select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 28px 6px 10px;
+  font-size: 14px;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml;utf8,<svg fill='none' stroke='%238D8D8D' stroke-width='2' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 14px 14px;
+  box-shadow: 0 0 0 1px #e9e9e9 inset;
 }
 
 @media (min-width:1024px){

--- a/src/features/products/services/ProductService.ts
+++ b/src/features/products/services/ProductService.ts
@@ -15,7 +15,7 @@ type GetParams = {
 
 export const ProductService = {
   async getProductSummaryList(p: GetParams): Promise<ProductSummaryList> {
-    const { userId, accessToken } = useSession.getState();
+    const { userId } = useSession.getState();
     
     if (!userId) throw new Error("NO_USER");
 

--- a/src/features/products/services/ProductService.ts
+++ b/src/features/products/services/ProductService.ts
@@ -1,0 +1,40 @@
+import { useSession } from "../../../hooks/useSession";
+import { apiAuthPathAndQuery } from "../../../shared/api";
+import type { ProductSummaryList } from "../types";
+
+type GetParams = {
+  category: string;
+  page: number;
+  size: number;
+  sortBy: "createdAt" | "unitPriceAmount" | "averageRating" | "reviewCount"; 
+  order: "asc" | "desc";
+  searchKeyword?: string;
+  minPrice?: number;
+  maxPrice?: number;
+};
+
+export const ProductService = {
+  async getProductSummaryList(p: GetParams): Promise<ProductSummaryList> {
+    const { userId, accessToken } = useSession.getState();
+    
+    if (!userId) throw new Error("NO_USER");
+
+    const q = {
+      category: p.category,
+      page: p.page,
+      size: p.size,
+      sortBy: p.sortBy,
+      order: p.order,
+      ...(p.searchKeyword ? { searchKeyword: p.searchKeyword } : {}),
+      ...(p.minPrice !== undefined ? { minPrice: p.minPrice } : {}),
+      ...(p.maxPrice !== undefined ? { maxPrice: p.maxPrice } : {}),
+    };
+
+    return apiAuthPathAndQuery<ProductSummaryList>(
+        "/products/{userId}", 
+        { userId }, 
+        q, 
+        { method: "GET" }
+    );
+  },
+};

--- a/src/features/products/types.ts
+++ b/src/features/products/types.ts
@@ -1,0 +1,20 @@
+export type ProductSummary = {
+  productId: string;      
+  name: string;
+  unitPriceAmount: number;
+  salePriceAmount: number | null;
+  averageRating: number;
+  reviewCount: number;
+  thumbnailUrl: string;
+  availability: string;
+};
+
+export type ProductSummaryList = {
+  products: ProductSummary[];
+  page: number;
+  size: number;
+  totalItems: number;
+  totalPages: number;
+};
+
+// export type ProductDetail 추후 작성 예정 

--- a/src/pages/products/ProductSummaryList.loader.ts
+++ b/src/pages/products/ProductSummaryList.loader.ts
@@ -1,0 +1,52 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import { ProductService } from "../../features/products/services/ProductService";
+
+export async function productSummaryListLoader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+
+  // Read query params from URL 
+  const page     = toInt(url.searchParams.get("page"), 1);
+  const size     = toInt(url.searchParams.get("size"), 16);
+  const category = (url.searchParams.get("category") ?? "all").trim();
+  const sortBy   = (url.searchParams.get("sortBy") ?? "createdAt").trim() as
+                   "createdAt" | "unitPriceAmount" | "averageRating" | "reviewCount";
+  const order    = (url.searchParams.get("order") ?? "desc").trim() as "asc" | "desc";
+
+  const kw       = (url.searchParams.get("searchKeyword") ?? "").trim();
+  const minPrice = toIntOpt(url.searchParams.get("minPrice"));
+  const maxPrice = toIntOpt(url.searchParams.get("maxPrice"));
+
+  // Mobile rule: ignore page/size and load a big chunk of data at once
+  const isMobile =
+  typeof window !== "undefined" &&
+  window.matchMedia("(max-width: 1024px)").matches;
+
+  const MOBILE_BIG_SIZE = 1000; // adjust as needed 
+
+  // Effective page/size to request
+  const effectivePage = isMobile ? 1 : page;
+  const effectiveSize = isMobile ? MOBILE_BIG_SIZE : size;
+
+  return ProductService.getProductSummaryList({
+    category, 
+    page: effectivePage, 
+    size: effectiveSize, 
+    sortBy, 
+    order,
+    ...(kw ? { searchKeyword: kw } : {}),
+    ...(minPrice!=null && maxPrice!=null && minPrice>maxPrice ? {} : {
+      ...(minPrice!=null ? { minPrice } : {}),
+      ...(maxPrice!=null ? { maxPrice } : {}),
+    }),
+  });
+}
+
+const toInt = (v: string | null, d: number) => {
+  const n = Number(v); 
+  return Number.isFinite(n) && n > 0 ? n : d;
+};
+const toIntOpt = (v: string | null) => {
+  if (v == null || v.trim() === "") return undefined;
+  const n = Number(v); 
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -33,6 +33,7 @@ import FAQPage from "../pages/customer/FAQPage";
 import QnAPage from "../pages/customer/QnAPage";
 import PolicyPage from "../pages/customer/PolicyPage";
 import { faqLoader } from "../pages/customer/FAQPage.loader";
+import { productSummaryListLoader } from "../pages/products/ProductSummaryList.loader"; 
 
 export const router = createBrowserRouter([
   { path: PATHS.intro, element: <IntroPage /> },
@@ -92,9 +93,23 @@ export const router = createBrowserRouter([
             handle: { header: { kind: "main", title: "문앞의책방" } } },
           { path: PATHS.productsHome,
             element: <ProductsHomePage />,
-            handle: { header: { kind: "main", title: "문앞의책방" } } },
+            loader: productSummaryListLoader,
+            handle: { 
+              header: { 
+              kind: "main", 
+              title: "문앞의책방" 
+              } 
+            } 
+          },
           { path: PATHS.productsSearch,
-            element: <ProductsSearchPage />},
+            element: <ProductsSearchPage />,
+            handle: { 
+              header: { 
+              kind: "main", 
+              title: "문앞의책방" 
+              } 
+            } 
+          },
           { path: PATHS.productsDetail,
             element: <ProductDetailPage />},
           { path: PATHS.loungeHome,


### PR DESCRIPTION
This patch would:
- define types ( ProductSummary, ProductSummaryList )
- add ProductService.getProductSummaryList 
- implement productSummaryListLoader 
- register loader in router for /products/home
- refactor ProductSummaryListHeader using URL params 
- apply loader data on ProductsHomePage 
  - list render
  - URL-driven pagination/search 