### PR TITLE
 Implement BooksCategoryHomePage with API integration

### DIFF
--- a/src/features/books/components/BookListHeader.tsx
+++ b/src/features/books/components/BookListHeader.tsx
@@ -8,6 +8,7 @@ type BookListHeaderProps = {
   selectedSort: string;
   onCategoryChange: (categoryValue: string) => void;
   onSortChange: (sortValue: string) => void;
+  categoryDisabled?: boolean;
 };
 
 export default function BookListHeader({
@@ -16,6 +17,7 @@ export default function BookListHeader({
   selectedSort,
   onCategoryChange,
   onSortChange,
+  categoryDisabled = false
 }: BookListHeaderProps) {
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -34,6 +36,7 @@ export default function BookListHeader({
             className={styles['category-select']}
             value={selectedCategory}
             onChange={handleCategoryChange}
+            disabled={categoryDisabled}
           >
             {categoryOptions.map(({ value, label }) => (
               <option key={value} value={value}>{label}</option>

--- a/src/features/books/components/BooksCategoryPopup.tsx
+++ b/src/features/books/components/BooksCategoryPopup.tsx
@@ -1,6 +1,8 @@
+import { generatePath, useNavigate } from 'react-router-dom';
 import { bookCategoryList } from '../types';
 import styles from './styles/BooksCategoryPopup.module.css';
 import { IoClose } from "react-icons/io5";
+import { PATHS } from '../../../routes/paths';
 
 type BooksCategoryPopupProps = {
   onClosed?: () => void;
@@ -9,6 +11,14 @@ type BooksCategoryPopupProps = {
 export default function BooksCategoryPopup({
   onClosed
 }: BooksCategoryPopupProps) {
+  const navigate = useNavigate();
+
+  const navigateToCategory = (categoryCodeName: string) => {
+    navigate(generatePath(PATHS.booksCategory, { categoryCodeName: categoryCodeName }));
+    if (onClosed) {
+      onClosed();
+    } // close popup after navigation
+  };
 
   return (
     <div className={styles['books-category-wrapper']}>
@@ -24,7 +34,7 @@ export default function BooksCategoryPopup({
       <div className={styles['category-list-wrapper']}>
         <button className={styles['category-all']}
           onClick={() => {
-            console.log(`카테고리 전체항목 클릭`);
+            navigateToCategory('all');
           }}
         >
           전체
@@ -35,7 +45,7 @@ export default function BooksCategoryPopup({
               key={value}
               className={styles['category-item']}
               onClick={() => {
-                console.log(`카테고리 ${label}항목 클릭`);
+                navigateToCategory(value);
               }}
             >
               {label}

--- a/src/features/books/components/BooksCategoryPopup.tsx
+++ b/src/features/books/components/BooksCategoryPopup.tsx
@@ -3,19 +3,17 @@ import { type BookCategory } from '../types';
 import styles from './styles/BooksCategoryPopup.module.css';
 import { IoClose } from "react-icons/io5";
 import { PATHS } from '../../../routes/paths';
-import { useEffect, useState } from 'react';
-import { BookService } from '../services/BookService';
 
 type BooksCategoryPopupProps = {
+  categories: BookCategory[];
   onClosed?: () => void;
 };
 
 export default function BooksCategoryPopup({
+  categories,
   onClosed
 }: BooksCategoryPopupProps) {
   const navigate = useNavigate();
-  const [categories, setCategories] = useState<{ value: string; label: string }[]>([]);
-
 
   const navigateToCategory = (categoryCodeName: string) => {
     navigate(generatePath(PATHS.booksCategory, { categoryCodeName: categoryCodeName }));
@@ -23,32 +21,6 @@ export default function BooksCategoryPopup({
       onClosed();
     } // close popup after navigation
   };
-
-  useEffect(() => {
-    let mounted = true;
-
-    async function loadCategories() {
-      try {
-        const data: BookCategory[] = await BookService.getBooksAllCategories();
-        if (!mounted) { return; }
-        const mapped = data.map(item => ({
-          value: item.categoryCodeName,
-          label: item.categoryDisplayName
-        }));
-        setCategories(mapped);
-      } catch {
-        if (!mounted) { return; }
-        setCategories([]);
-      }
-    }
-
-    loadCategories();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
 
   return (
     <div className={styles['books-category-wrapper']}>
@@ -70,15 +42,13 @@ export default function BooksCategoryPopup({
           전체
         </button>
         <div className={styles['category-items']}>
-          {categories.map(({ value, label }) => (
+          {categories.map(cat => (
             <button
-              key={value}
+              key={cat.categoryCodeName}
               className={styles['category-item']}
-              onClick={() => {
-                navigateToCategory(value);
-              }}
+              onClick={() => navigateToCategory(cat.categoryCodeName)}
             >
-              {label}
+              {cat.categoryDisplayName}
             </button>
           ))}
         </div>

--- a/src/features/books/components/BooksCategoryPopup.tsx
+++ b/src/features/books/components/BooksCategoryPopup.tsx
@@ -1,11 +1,6 @@
+import { bookCategoryList } from '../types';
 import styles from './styles/BooksCategoryPopup.module.css';
 import { IoClose } from "react-icons/io5";
-
-const categories = [
-  "소설", "시/에세이", "인문", "가정/육아", "요리", "건강", "취미/실용/스포츠",
-  "경제/경영", "자기계발", "정치/사회", "역사/문화", "종교", "예술/대중문화",
-  "기술/공학", "외국어", "과학", "여행", "컴퓨터/IT"
-];
 
 type BooksCategoryPopupProps = {
   onClosed?: () => void;
@@ -35,15 +30,15 @@ export default function BooksCategoryPopup({
           전체
         </button>
         <div className={styles['category-items']}>
-          {categories.map((category, idx) => (
+          {bookCategoryList.map(({value, label}) => (
             <button
-              key={idx}
+              key={value}
               className={styles['category-item']}
               onClick={() => {
-                console.log(`카테고리 ${category}항목 클릭`);
+                console.log(`카테고리 ${label}항목 클릭`);
               }}
             >
-              {category}
+              {label}
             </button>
           ))}
         </div>

--- a/src/features/books/components/BooksCategoryPopup.tsx
+++ b/src/features/books/components/BooksCategoryPopup.tsx
@@ -1,8 +1,10 @@
 import { generatePath, useNavigate } from 'react-router-dom';
-import { bookCategoryList } from '../types';
+import { type BookCategory } from '../types';
 import styles from './styles/BooksCategoryPopup.module.css';
 import { IoClose } from "react-icons/io5";
 import { PATHS } from '../../../routes/paths';
+import { useEffect, useState } from 'react';
+import { BookService } from '../services/BookService';
 
 type BooksCategoryPopupProps = {
   onClosed?: () => void;
@@ -12,6 +14,8 @@ export default function BooksCategoryPopup({
   onClosed
 }: BooksCategoryPopupProps) {
   const navigate = useNavigate();
+  const [categories, setCategories] = useState<{ value: string; label: string }[]>([]);
+
 
   const navigateToCategory = (categoryCodeName: string) => {
     navigate(generatePath(PATHS.booksCategory, { categoryCodeName: categoryCodeName }));
@@ -19,6 +23,32 @@ export default function BooksCategoryPopup({
       onClosed();
     } // close popup after navigation
   };
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadCategories() {
+      try {
+        const data: BookCategory[] = await BookService.getBooksAllCategories();
+        if (!mounted) { return; }
+        const mapped = data.map(item => ({
+          value: item.categoryCodeName,
+          label: item.categoryDisplayName
+        }));
+        setCategories(mapped);
+      } catch {
+        if (!mounted) { return; }
+        setCategories([]);
+      }
+    }
+
+    loadCategories();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
 
   return (
     <div className={styles['books-category-wrapper']}>
@@ -40,7 +70,7 @@ export default function BooksCategoryPopup({
           전체
         </button>
         <div className={styles['category-items']}>
-          {bookCategoryList.map(({value, label}) => (
+          {categories.map(({ value, label }) => (
             <button
               key={value}
               className={styles['category-item']}
@@ -53,7 +83,6 @@ export default function BooksCategoryPopup({
           ))}
         </div>
       </div>
-
     </div>
   );
 }

--- a/src/features/books/components/styles/BookListHeader.module.css
+++ b/src/features/books/components/styles/BookListHeader.module.css
@@ -32,6 +32,14 @@
   border: none;
   cursor: pointer;
 }
+.category-select:disabled {
+  color: #000;
+  cursor: default;
+}
+
+.disabled-icon {
+  opacity: 0.4;
+}
 .category-icon {
   position: absolute;
   right: 0px;
@@ -66,6 +74,7 @@
   align-items: center;
   align-self: stretch;
   border: none;
+  cursor: pointer;
 }
 
 /*

--- a/src/features/books/resources/bookDetailsPage.dummy.ts
+++ b/src/features/books/resources/bookDetailsPage.dummy.ts
@@ -1,3 +1,26 @@
+export const bookBannersDummy = [
+  {
+    id: '1',
+    mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/b6184cd613704109a7e830ea4f75b515.jpg',
+    desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/91122066f6654d40ae83686dcb2267e5.jpg'
+  },
+  {
+    id: '2',
+    mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/71a6e24dcb274056852a83b665c77d8d.jpg',
+    desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/c9797b7b332d4670bc364e17f17a597f.jpg'
+  },
+  {
+    id: '3',
+    mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/4a317505f8364ad2b08322d77ed51823.jpg',
+    desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/32d8920d082e410bb65f661b5651b97b.jpg'
+  },
+  {
+    id: '4',
+    mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/f246603304ea4bfba8627ecc13895ee8.jpg',
+    desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/b6c6814fda0848f6b6b00cedcb684c0e.jpg'
+  }
+]; 
+
 export const myMbtiDummy = 'ISFP';
 
 export const mbtiResearchDummy = [

--- a/src/features/books/services/BookService.ts
+++ b/src/features/books/services/BookService.ts
@@ -1,6 +1,6 @@
 import { apiAuthPath, apiAuthPathAndQuery } from "../../../shared/api";
 import { useSession } from "../../../hooks/useSession";
-import type { BooksApiResponse, BookSummary, BookDetails } from "../types";
+import type { BooksApiResponse, BookSummary, BookDetails, BookCategory, BookSubcategory } from "../types";
 
 export const BookService = {
 
@@ -43,6 +43,34 @@ export const BookService = {
     return apiAuthPath<BookDetails>(
       "/books/{userId}/{bookId}",
       { userId, bookId },
+      { method: "GET" }
+    );
+  },
+
+  // API-BOOKS-11 : Fetch all book categories
+  async getBooksAllCategories(
+  ): Promise<BookCategory[]> {
+    const { userId } = useSession.getState();
+    if (!userId) { throw new Error("NO_USER"); }
+
+    return apiAuthPath<BookCategory[]>(
+      "/books/{userId}/categories",
+      { userId },
+      { method: "GET" }
+    );
+  },
+
+  // API-BOOKS-12 : Fetch subcategories for a specific category
+  async getBookSubcategories(
+    categoryCodeName: string
+  ): Promise<BookSubcategory[]> {
+    const { userId } = useSession.getState();
+    if (!userId) { throw new Error("NO_USER"); }
+    if (!categoryCodeName) { throw new Error("NO_CATERGORY"); }
+
+    return apiAuthPath<BookSubcategory[]>(
+      "/books/{userId}/categories/{categoryCodeName}/subcategories",
+      { userId, categoryCodeName },
       { method: "GET" }
     );
   },

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -76,15 +76,18 @@ export const SEARCH_OPTIONS: { value: SearchOption; label: string }[] = [
   { value: 'publisher', label: '출판사' },
 ] as const;
 
-export type SearchState = {
+export type CommonSearchState = {
   category: string;
   subcategory: string;
   page: number;
   size: number;
-  searchBy: 'title' | 'author' | 'publisher';
-  searchKeyword: string;
   sortBy: 'published' | 'views' | 'sales' | 'rentals' | 'price';
   order: 'asc' | 'desc';
+};
+
+export type BookSearchState = CommonSearchState & {
+  searchBy: 'title' | 'author' | 'publisher';
+  searchKeyword: string;
   minPrice?: number;
   maxPrice?: number;
 };

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -163,3 +163,25 @@ export type BookReview = {
   likeCount: number,
   likedByMe: boolean
 }
+
+// temp before connect API logic
+export const bookCategoryList = [
+  { value: 'fiction', label: '소설' },
+  { value: 'essay', label: '시/에세이' },
+  { value: 'humanities', label: '인문' },
+  { value: 'parenting', label: '가정/육아' },
+  { value: 'cooking', label: '요리' },
+  { value: 'health', label: '건강' },
+  { value: 'lifestyle', label: '취미/실용/스포츠' },
+  { value: 'business', label: '경제/경영' },
+  { value: 'selfImprovement', label: '자기계발' },
+  { value: 'politics', label: '정치/사회' },
+  { value: 'culture', label: '역사/문화' },
+  { value: 'religion', label: '종교' },
+  { value: 'entertainment', label: '예술/대중문화' },
+  { value: 'technology', label: '기술/공학' },
+  { value: 'language', label: '외국어' },
+  { value: 'science', label: '과학' },
+  { value: 'travel', label: '여행' },
+  { value: 'it', label: '컴퓨터/IT' },
+];

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -56,6 +56,18 @@ export type BookDetails = {
   ratingCount: number;
 };
 
+export type BookCategory = {
+  id: string;
+  categoryCodeName: string;
+  categoryDisplayName: string;
+};
+
+export type BookSubcategory = {
+  id: string;
+  subcategoryCodeName: string;
+  subcategoryDisplayName: string;
+};
+
 export type SearchOption = 'title' | 'author' | 'publisher';
 
 export const SEARCH_OPTIONS: { value: SearchOption; label: string }[] = [
@@ -163,25 +175,3 @@ export type BookReview = {
   likeCount: number,
   likedByMe: boolean
 }
-
-// temp before connect API logic
-export const bookCategoryList = [
-  { value: 'fiction', label: '소설' },
-  { value: 'essay', label: '시/에세이' },
-  { value: 'humanities', label: '인문' },
-  { value: 'parenting', label: '가정/육아' },
-  { value: 'cooking', label: '요리' },
-  { value: 'health', label: '건강' },
-  { value: 'lifestyle', label: '취미/실용/스포츠' },
-  { value: 'business', label: '경제/경영' },
-  { value: 'selfImprovement', label: '자기계발' },
-  { value: 'politics', label: '정치/사회' },
-  { value: 'culture', label: '역사/문화' },
-  { value: 'religion', label: '종교' },
-  { value: 'entertainment', label: '예술/대중문화' },
-  { value: 'technology', label: '기술/공학' },
-  { value: 'language', label: '외국어' },
-  { value: 'science', label: '과학' },
-  { value: 'travel', label: '여행' },
-  { value: 'it', label: '컴퓨터/IT' },
-];

--- a/src/pages/books/BooksCategory.loader.ts
+++ b/src/pages/books/BooksCategory.loader.ts
@@ -1,19 +1,64 @@
 import type { LoaderFunctionArgs } from "react-router-dom";
-import type { BookCategory } from "../../features/books/types";
+import type { BookCategory, BookDetails, BookSummary } from "../../features/books/types";
 import { BookService } from "../../features/books/services/BookService";
 
 export type BooksCategoryLoaderData = {
   bookCategories: BookCategory[],
+  top3BestSellers: BookDetails[];
+  newBooksBySection: { key: string; label: string; books: BookSummary[] }[];
 };
 
-export async function booksCategoryLoader(_args: LoaderFunctionArgs): Promise<BooksCategoryLoaderData> {
+export async function booksCategoryLoader({ params }: LoaderFunctionArgs): Promise<BooksCategoryLoaderData> {
 
-  try {
-    const bookCategories = await BookService.getBooksAllCategories();
+  const categoryCodeName = params.categoryCodeName ?? 'all';
 
-    return { bookCategories };
-  } catch (error) {
-    console.error("booksCategoryLoader error", error);
-    throw new Error("booksCategoryLoader: failed to fetch");
+  // always request top3 bestsellers
+  const top3Promise = BookService.getDetailedBooks(categoryCodeName, 'all', 1, 3, 'sales', 'desc');
+
+  // newBooks loading branch: if category is 'all' load by category, otherwise load by subcategory for the given category
+  let newBooksPromise: Promise<BooksCategoryLoaderData['newBooksBySection']> = Promise.resolve([]);
+
+  if (categoryCodeName === 'all') {
+    newBooksPromise = (async () => {
+      try {
+        const categories = await BookService.getBooksAllCategories();
+        const results = await Promise.all(categories.map(async (cat) => {
+          try {
+            const books = await BookService.getBookSummaries(cat.categoryCodeName, 'all', 1, 7, 'published', 'desc');
+            return { key: cat.categoryCodeName, label: cat.categoryDisplayName, books };
+          } catch {
+            return { key: cat.categoryCodeName, label: cat.categoryDisplayName, books: [] };
+          }
+        }));
+        return results;
+      } catch {
+        return [];
+      }
+    })();
+  } else {
+    newBooksPromise = (async () => {
+      try {
+        const subcats = await BookService.getBookSubcategories(categoryCodeName);
+        const results = await Promise.all((subcats || []).map(async (sub) => {
+          try {
+            const books = await BookService.getBookSummaries(categoryCodeName, sub.subcategoryCodeName, 1, 7, 'published', 'desc');
+            return { key: sub.subcategoryCodeName, label: sub.subcategoryDisplayName, books };
+          } catch {
+            return { key: sub.subcategoryCodeName, label: sub.subcategoryDisplayName, books: [] };
+          }
+        }));
+        return results;
+      } catch {
+        return [];
+      }
+    })();
   }
+
+  const [top3BestSellers, newBooksBySection, bookCategories] = await Promise.all([
+    top3Promise.catch(() => []),
+    newBooksPromise.catch(() => []),
+    BookService.getBooksAllCategories().catch(() => []),
+  ]);
+
+  return { bookCategories, top3BestSellers, newBooksBySection };
 }

--- a/src/pages/books/BooksCategory.loader.ts
+++ b/src/pages/books/BooksCategory.loader.ts
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import type { BookCategory } from "../../features/books/types";
+import { BookService } from "../../features/books/services/BookService";
+
+export type BooksCategoryLoaderData = {
+  bookCategories: BookCategory[],
+};
+
+export async function booksCategoryLoader(_args: LoaderFunctionArgs): Promise<BooksCategoryLoaderData> {
+
+  try {
+    const bookCategories = await BookService.getBooksAllCategories();
+
+    return { bookCategories };
+  } catch (error) {
+    console.error("booksCategoryLoader error", error);
+    throw new Error("booksCategoryLoader: failed to fetch");
+  }
+}

--- a/src/pages/books/BooksCategoryAllPage.tsx
+++ b/src/pages/books/BooksCategoryAllPage.tsx
@@ -1,16 +1,154 @@
-import { useParams } from "react-router-dom";
-import { categoryOptions } from "../../features/books/types";
+import styles from './styles/BooksCategoryAllPage.module.css';
+import { generatePath, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { sortOptions, type BookSummary, type CommonSearchState } from "../../features/books/types";
+import BookListHeader from '../../features/books/components/BookListHeader';
+import BookListItem from '../../features/books/components/BookListItem';
+import Pagination from '../../components/navigation/Pagination';
+import { PATHS } from '../../routes/paths';
+import { useEffect, useState } from 'react';
+import { BookService } from '../../features/books/services/BookService';
+
+// Parse initial search state from URL: page, category, subcategory, minPrice, maxPrice, searchBy, keyword, sortBy, order
+function makeInitialState(params: URLSearchParams, defaultCategory?: string): CommonSearchState {
+  return {
+    category: defaultCategory ?? params.get('category') ?? 'all',
+    subcategory: params.get('subcategory') ?? 'all',
+    page: Number(params.get('page') ?? 1),
+    size: Number(params.get('size') ?? 10),
+    sortBy: (params.get('sortBy') as CommonSearchState['sortBy']) ?? 'published',
+    order: (params.get('order') as CommonSearchState['order']) ?? 'desc',
+  };
+}
+
+// Utility function to update URLSearchParams
+const applyQueryParam = (q: URLSearchParams, key: string, value: string | number | undefined, defaultValue?: string) => {
+  if (value !== undefined) {
+    q.set(key, String(value));
+  } else if (defaultValue !== undefined) {
+    q.set(key, defaultValue);
+  }
+};
 
 export default function BooksCategoryAllPage() {
+  const navigate = useNavigate();
+
   const params = useParams();
   const categoryCodeName = params.categoryCodeName;
-  const categoryLabel = categoryOptions.find(c => c.value === categoryCodeName)?.label ?? categoryCodeName;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [books, setBooks] = useState<BookSummary[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const [searchState, setSearchState] = useState<CommonSearchState>(() =>
+    makeInitialState(searchParams, categoryCodeName)
+  );
+
+  // Update URL (query) as single source of truth
+  const setQuery = (updater: (q: URLSearchParams) => void) => {
+    const q = new URLSearchParams(searchParams.toString());
+    updater(q);
+    setSearchParams(q);
+  };
+
+  // Update search state via URL (filters, category, sort, price, page)
+  const updateSearchStateViaUrl = (updates: Partial<CommonSearchState>) => {
+    setQuery(q => {
+      applyQueryParam(q, 'category', updates.category);
+      applyQueryParam(q, 'subcategory', updates.subcategory);
+      applyQueryParam(q, 'sortBy', updates.sortBy);
+      applyQueryParam(q, 'order', updates.order);
+      applyQueryParam(q, 'page', updates.page, '1');
+    });
+  };
+
+  // Handler for BookListHeader component category select change
+  const handleCategoryChange = (categoryValue: string) => {
+    updateSearchStateViaUrl({ category: categoryValue })
+  };
+  
+  // Handler for BookListHeader component sort select change
+  const handleSortChange = (sortValue: string) => {
+    const option = sortOptions.find(option => option.value === sortValue);
+    if (!option) return;
+    updateSearchStateViaUrl({ sortBy: option.value, order: option.order });
+  };
+
+  // Handler for Pagination component page change
+  const handlePageChange = (nextPage: number) => {
+    setQuery(q => q.set('page', String(nextPage)));
+  };
+
+  const handleBookItemClick = (id: string) => {
+    navigate(generatePath(PATHS.bookDetails, { bookId: id }));
+  };
+
+  // Sync searchState with URL changes
+  useEffect(() => {
+    setSearchState(makeInitialState(searchParams, categoryCodeName));
+  }, [searchParams, categoryCodeName]);
+
+  // Fetch data when searchState changes
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await BookService.getPaginatedBookSummaries(
+          searchState.category,
+          searchState.subcategory,
+          searchState.page,
+          searchState.size,
+          searchState.sortBy,
+          searchState.order
+        );
+        if (cancelled) return;
+        setBooks(res.books);
+        setTotalItems(res.totalItems);
+        setTotalPages(res.totalPages);
+      } catch (error) {
+        if (cancelled) return;
+        console.error('검색 결과 불러오기 실패', error);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [searchState]);
+
   return (
-    <main>
-      <div>
-        <h1>Knockbook BooksCategoryAllPage</h1>
-        <h2>{categoryLabel}</h2>
+    <div className={styles['book-search-results-container']}>
+      <div className={styles['book-search-results']}>
+        <BookListHeader
+          totalCount={totalItems}
+          selectedCategory={searchState.category}
+          selectedSort={searchState.sortBy}
+          onCategoryChange={handleCategoryChange}
+          onSortChange={handleSortChange}
+          categoryDisabled={true}
+        />
+        {books.map((book) => (
+          <BookListItem
+            key={book.id}
+            imageUrl={book.coverThumbnailUrl}
+            title={book.title}
+            author={book.author}
+            publisher={book.publisher}
+            publishedAt={book.publishedAt}
+            averageRating={book.averageRating}
+            rentalAmount={book.rentalAmount}
+            purchaseAmount={book.purchaseAmount}
+            discountedPurchaseAmount={book.discountedPurchaseAmount}
+            onImageOrTitleClicked={() => {
+              handleBookItemClick(book.id);
+              console.log(`${book.title} 도서 클릭`);
+            }}
+          />
+        ))}
       </div>
-    </main>
+      <Pagination
+        page={Number(searchParams.get('page') ?? searchState.page)}
+        totalPages={totalPages}
+        onChange={handlePageChange}
+      />
+    </div>
   );
 }

--- a/src/pages/books/BooksCategoryAllPage.tsx
+++ b/src/pages/books/BooksCategoryAllPage.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { categoryOptions } from "../../features/books/types";
+
+export default function BooksCategoryAllPage() {
+  const params = useParams();
+  const categoryCodeName = params.categoryCodeName;
+  const categoryLabel = categoryOptions.find(c => c.value === categoryCodeName)?.label ?? categoryCodeName;
+  return (
+    <main>
+      <div>
+        <h1>Knockbook BooksCategoryAllPage</h1>
+        <h2>{categoryLabel}</h2>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/books/BooksCategoryHomePage.tsx
+++ b/src/pages/books/BooksCategoryHomePage.tsx
@@ -1,16 +1,107 @@
-import { useParams } from "react-router-dom";
-import { categoryOptions } from "../../features/books/types";
+import styles from './styles/BooksCategoryHomePage.module.css';
+import { generatePath, useNavigate, useParams } from "react-router-dom";
+import { type BookDetails, type BookSummary } from "../../features/books/types";
+import BookSectionHeader from "../../features/books/components/BookSectionHeader";
+import BestSellerSection from "../../features/books/components/BookBestSeller";
+import BookCardForBookSlider from "../../features/books/components/BookCardForBookSlider";
+import BookSlider from "../../features/books/components/BookSlider";
+import { PATHS } from "../../routes/paths";
+import { BookService } from '../../features/books/services/BookService';
+import { useEffect, useState } from 'react';
+
+type SubcategoryWithBooks = {
+  key: string;
+  label: string;
+  books: BookSummary[];
+};
 
 export default function BooksCategoryHomePage() {
+  const navigate = useNavigate();
   const params = useParams();
   const categoryCodeName = params.categoryCodeName;
-  const categoryLabel = categoryOptions.find(c => c.value === categoryCodeName)?.label ?? categoryCodeName;
+  const [top3BestSellers, setTop3BestSellers] = useState<BookDetails[]>([]);
+  const [newBooks, setNewBooks] = useState<SubcategoryWithBooks[]>([]);
+
+  useEffect(() => {
+    if (!categoryCodeName) return;
+    let mounted = true;
+
+    async function load() {
+      try {
+        if(!categoryCodeName) { throw new Error; }
+        const top3 = await BookService.getDetailedBooks(categoryCodeName, 'all', 1, 3, 'sales', 'desc');
+        const subcats = await BookService.getBookSubcategories(categoryCodeName);
+        const newBooksRes = await Promise.all(
+          (subcats || []).map(async (sub) => {
+            const books = await BookService.getBookSummaries(categoryCodeName, sub.subcategoryCodeName, 1, 7, "published", "desc");
+            return { key: sub.subcategoryCodeName, label: sub.subcategoryDisplayName, books };
+          })
+        );
+        if (!mounted) return;
+        setTop3BestSellers(top3);
+        setNewBooks(newBooksRes);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    load();
+    return () => { mounted = false; };
+  }, [categoryCodeName]);
+
+  const handleBookItemClick = (id: string) => {
+    navigate(generatePath(PATHS.bookDetails, { bookId: id }));
+  };
+
   return (
-    <main>
-      <div>
-        <h1>Knockbook BooksCategoryHomePage</h1>
-        <h2>{categoryLabel}</h2>
-      </div>
-    </main>
+    <div className={styles['book-contents-container']}>
+      <section className={styles['best-seller-section']}>
+        <BookSectionHeader 
+          headerTitle="문앞 베스트"
+          onClicked={() => console.log('문앞 베스트 더보기 클릭')}
+        />
+        <BestSellerSection
+          top3Books={top3BestSellers}
+          onFirstBookClicked={() => {
+            handleBookItemClick(top3BestSellers[0].id);
+            console.log('1위 도서 클릭');
+          }}
+          onSecondBookClicked={() => {
+            handleBookItemClick(top3BestSellers[1].id);
+            console.log('2위 도서 클릭');
+          }}
+          onThirdBookClicked={() => {
+            handleBookItemClick(top3BestSellers[2].id);
+            console.log('3위 도서 클릭');
+          }}
+        />
+      </section>
+
+      {/* Render category-specific sliders */}
+      {newBooks.map(sub => (
+        <section key={sub.key} className={styles['book-slider-section']}>
+          <BookSectionHeader 
+            headerTitle="새로나온 책" 
+            categoryName={sub.label}
+            onClicked={() => console.log(`${sub.label} 더보기 클릭`)}
+          />
+          <BookSlider>
+            {(sub.books || []).map(book => (
+              <BookCardForBookSlider
+                key={book.id}
+                imageUrl={book.coverThumbnailUrl}
+                title={book.title}
+                author={book.author}
+                publisher={book.publisher}
+                onImageOrTitleClicked={() => {
+                  handleBookItemClick(book.id);
+                  console.log(`${book.title} 클릭`);
+                }}
+              />
+            ))}
+          </BookSlider>
+        </section>
+      ))}
+    </div>
   );
 }

--- a/src/pages/books/BooksCategoryHomePage.tsx
+++ b/src/pages/books/BooksCategoryHomePage.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { categoryOptions } from "../../features/books/types";
+
+export default function BooksCategoryHomePage() {
+  const params = useParams();
+  const categoryCodeName = params.categoryCodeName;
+  const categoryLabel = categoryOptions.find(c => c.value === categoryCodeName)?.label ?? categoryCodeName;
+  return (
+    <main>
+      <div>
+        <h1>Knockbook BooksCategoryHomePage</h1>
+        <h2>{categoryLabel}</h2>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/books/BooksCategoryPage.tsx
+++ b/src/pages/books/BooksCategoryPage.tsx
@@ -4,13 +4,16 @@ import Banner from "../../components/display/BannerSlider";
 import Footer from "../../components/layout/Footer";
 import BooksCategoryPopup from "../../features/books/components/BooksCategoryPopup";
 import { useState } from "react";
-import { Outlet, useNavigate, useParams } from "react-router-dom";
+import { Outlet, useLoaderData, useNavigate, useParams } from "react-router-dom";
 import TwoLevelTabMenu from "../../components/navigation/TwoLevelTabMenu";
 import { bookBannersDummy } from "../../features/books/resources/bookDetailsPage.dummy";
 import { categoryOptions } from "../../features/books/types";
+import type { BooksCategoryLoaderData } from "./BooksCategory.loader";
 
 export default function BooksCategoryPage() {
-  const navigate = useNavigate();  
+  const navigate = useNavigate();
+
+  const { bookCategories } = useLoaderData() as BooksCategoryLoaderData;
   const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
 
   const params = useParams();
@@ -44,7 +47,10 @@ export default function BooksCategoryPage() {
         />
         {isCategoryPopupOpen && (
           <div className={styles['category-popup-overlay']}>
-            <BooksCategoryPopup onClosed={handleCloseCategory} />
+            <BooksCategoryPopup
+              categories={bookCategories}
+              onClosed={handleCloseCategory}
+            />
           </div>
         )}
         <h1 className={styles['book-category-title']}>

--- a/src/pages/books/BooksCategoryPage.tsx
+++ b/src/pages/books/BooksCategoryPage.tsx
@@ -47,7 +47,9 @@ export default function BooksCategoryPage() {
             <BooksCategoryPopup onClosed={handleCloseCategory} />
           </div>
         )}
-        <h1>카테고리: {categoryLabel}</h1>
+        <h1 className={styles['book-category-title']}>
+          {`카테고리: ${categoryLabel}`}
+        </h1>
         <section>
           <Banner items={banners}/>
         </section>

--- a/src/pages/books/BooksCategoryPage.tsx
+++ b/src/pages/books/BooksCategoryPage.tsx
@@ -1,0 +1,65 @@
+import CategoryFilterSearchBar from "../../features/books/components/CategoryFilterSearchBar";
+import styles from './styles/BooksCategoryPage.module.css';
+import Banner from "../../components/display/BannerSlider";
+import Footer from "../../components/layout/Footer";
+import BooksCategoryPopup from "../../features/books/components/BooksCategoryPopup";
+import { useState } from "react";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
+import TwoLevelTabMenu from "../../components/navigation/TwoLevelTabMenu";
+import { bookBannersDummy } from "../../features/books/resources/bookDetailsPage.dummy";
+import { categoryOptions } from "../../features/books/types";
+
+export default function BooksCategoryPage() {
+  const navigate = useNavigate();  
+  const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
+
+  const params = useParams();
+  const categoryCodeName = params.categoryCodeName;
+  const categoryLabel = categoryOptions.find(c => c.value === categoryCodeName)?.label ?? categoryCodeName;
+
+
+  const banners = bookBannersDummy;
+
+  const handleSearch = (searchBy: 'title' | 'author' | 'publisher', searchKeyword: string) => {
+    navigate(`/books/search?by=${searchBy}&keyword=${encodeURIComponent(searchKeyword)}`);
+    console.log('🔍 검색 실행:', { searchBy, searchKeyword });
+  };
+
+  const toggleCategory = () => {
+    setIsCategoryPopupOpen(prev => !prev);
+    console.log(`📂 카테고리 ${!isCategoryPopupOpen ? '열기' : '닫기'}`);
+  };
+
+  const handleCloseCategory = () => {
+    setIsCategoryPopupOpen(false);
+    console.log('📂 카테고리 팝업 닫기');
+  };
+
+  return (
+    <>
+      <main className={styles['book-category-main']}>
+        <CategoryFilterSearchBar
+          onSearched={handleSearch}
+          onCategoryToggled={toggleCategory}
+        />
+        {isCategoryPopupOpen && (
+          <div className={styles['category-popup-overlay']}>
+            <BooksCategoryPopup onClosed={handleCloseCategory} />
+          </div>
+        )}
+        <h1>카테고리: {categoryLabel}</h1>
+        <section>
+          <Banner items={banners}/>
+        </section>
+        <TwoLevelTabMenu
+          leftTabTitle="홈"
+          rightTabTitle="전체보기"
+          leftTabPath="home"
+          rightTabPath="all"
+        />
+        <Outlet />
+      </main>
+      <Footer/>
+    </>
+  );
+}

--- a/src/pages/books/BooksHome.loader.ts
+++ b/src/pages/books/BooksHome.loader.ts
@@ -1,8 +1,9 @@
 import type { LoaderFunctionArgs } from "react-router-dom";
-import type { BookDetails, BookSummary } from "../../features/books/types";
+import type { BookCategory, BookDetails, BookSummary } from "../../features/books/types";
 import { BookService } from "../../features/books/services/BookService";
 
 export type BooksHomeLoaderData = {
+  bookCategories: BookCategory[],
   top3BestSellers: BookDetails[];
   booksByCategory: Record<string, BookSummary[]>;
 };
@@ -18,6 +19,8 @@ export const booksHomeNewReleaseCategories = [
 export async function booksHomeLoader(_args: LoaderFunctionArgs): Promise<BooksHomeLoaderData> {
 
   try {
+    const bookCategories = await BookService.getBooksAllCategories();
+
     const top3BestSellers = await BookService.getDetailedBooks('all', 'all', 1, 3, 'sales', 'desc');
 
     const categoryResults = await Promise.all(
@@ -30,9 +33,9 @@ export async function booksHomeLoader(_args: LoaderFunctionArgs): Promise<BooksH
     const booksByCategory: Record<string, BookSummary[]> = {};
     categoryResults.forEach(r => { booksByCategory[r.key] = r.books; });
 
-    return { top3BestSellers, booksByCategory };
+    return { bookCategories, top3BestSellers, booksByCategory };
   } catch (error) {
     console.error("booksHomeLoader error", error);
-    throw new Error("booksHomeLoader: failed to fetch books");
+    throw new Error("booksHomeLoader: failed to fetch");
   }
 }

--- a/src/pages/books/BooksHomePage.tsx
+++ b/src/pages/books/BooksHomePage.tsx
@@ -16,7 +16,7 @@ import { bookBannersDummy } from '../../features/books/resources/bookDetailsPage
 export default function BooksHomePage() {
   const navigate = useNavigate();
   
-  const { top3BestSellers, booksByCategory } = useLoaderData() as BooksHomeLoaderData;
+  const { bookCategories, top3BestSellers, booksByCategory } = useLoaderData() as BooksHomeLoaderData;
   const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
 
   const banners = bookBannersDummy;
@@ -49,7 +49,10 @@ export default function BooksHomePage() {
         />
         {isCategoryPopupOpen && (
           <div className={styles['category-popup-overlay']}>
-            <BooksCategoryPopup onClosed={handleCloseCategory} />
+            <BooksCategoryPopup
+              categories={bookCategories}
+              onClosed={handleCloseCategory}
+            />
           </div>
         )}
         <section>

--- a/src/pages/books/BooksHomePage.tsx
+++ b/src/pages/books/BooksHomePage.tsx
@@ -11,12 +11,15 @@ import { useState } from "react";
 import { generatePath, useLoaderData, useNavigate } from "react-router-dom";
 import { booksHomeNewReleaseCategories, type BooksHomeLoaderData } from "./BooksHome.loader";
 import { PATHS } from "../../routes/paths";
+import { bookBannersDummy } from '../../features/books/resources/bookDetailsPage.dummy';
 
 export default function BooksHomePage() {
   const navigate = useNavigate();
   
   const { top3BestSellers, booksByCategory } = useLoaderData() as BooksHomeLoaderData;
   const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
+
+  const banners = bookBannersDummy;
   
   const handleSearch = (searchBy: 'title' | 'author' | 'publisher', searchKeyword: string) => {
     navigate(`/books/search?by=${searchBy}&keyword=${encodeURIComponent(searchKeyword)}`);
@@ -36,30 +39,6 @@ export default function BooksHomePage() {
   const handleBookItemClick = (id: string) => {
     navigate(generatePath(PATHS.bookDetails, { bookId: id }));
   };
-
-  // Dummy data for Banners
-  const banners = [
-    {
-      id: '1',
-      mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/b6184cd613704109a7e830ea4f75b515.jpg',
-      desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/91122066f6654d40ae83686dcb2267e5.jpg'
-    },
-    {
-      id: '2',
-      mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/71a6e24dcb274056852a83b665c77d8d.jpg',
-      desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/c9797b7b332d4670bc364e17f17a597f.jpg'
-    },
-    {
-      id: '3',
-      mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/4a317505f8364ad2b08322d77ed51823.jpg',
-      desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/32d8920d082e410bb65f661b5651b97b.jpg'
-    },
-    {
-      id: '4',
-      mobileImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/f246603304ea4bfba8627ecc13895ee8.jpg',
-      desktopImageUrl: 'https://contents.kyobobook.co.kr/pmtn/2025/event/b6c6814fda0848f6b6b00cedcb684c0e.jpg'
-    }
-  ]; 
 
   return (
     <>

--- a/src/pages/books/BooksSearch.loader.ts
+++ b/src/pages/books/BooksSearch.loader.ts
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import type { BookCategory } from "../../features/books/types";
+import { BookService } from "../../features/books/services/BookService";
+
+export type BooksSearchLoaderData = {
+  bookCategories: BookCategory[],
+};
+
+export async function booksSearchLoader(_args: LoaderFunctionArgs): Promise<BooksSearchLoaderData> {
+
+  try {
+    const bookCategories = await BookService.getBooksAllCategories();
+
+    return { bookCategories };
+  } catch (error) {
+    console.error("booksSearchLoader error", error);
+    throw new Error("booksSearchLoader: failed to fetch");
+  }
+}

--- a/src/pages/books/BooksSearchPage.tsx
+++ b/src/pages/books/BooksSearchPage.tsx
@@ -4,7 +4,7 @@ import Footer from "../../components/layout/Footer";
 import BooksCategoryPopup from "../../features/books/components/BooksCategoryPopup";
 import { useEffect, useState } from "react";
 import { generatePath, useNavigate, useSearchParams } from "react-router-dom";
-import { SEARCH_OPTIONS, sortOptions, type BookSummary, type SearchOption, type SearchState } from "../../features/books/types.ts";
+import { SEARCH_OPTIONS, sortOptions, type BookSearchState, type BookSummary, type SearchOption } from "../../features/books/types.ts";
 import BookListItem from "../../features/books/components/BookListItem";
 import BookListHeader from "../../features/books/components/BookListHeader";
 import BookFilterSidebar from "../../features/books/components/BookFilterSidebar";
@@ -13,7 +13,7 @@ import Pagination from "../../components/navigation/Pagination.tsx";
 import { PATHS } from "../../routes/paths.ts";
 
 // Parse initial search state from URL: page, category, subcategory, minPrice, maxPrice, searchBy, keyword, sortBy, order
-function makeInitialState(params: URLSearchParams): SearchState {
+function makeInitialState(params: URLSearchParams): BookSearchState {
   return {
     category: params.get('category') ?? 'all',
     subcategory: params.get('subcategory') ?? 'all',
@@ -21,8 +21,8 @@ function makeInitialState(params: URLSearchParams): SearchState {
     size: Number(params.get('size') ?? 10),
     searchBy: (params.get('by') as 'title'|'author'|'publisher') ?? 'title',
     searchKeyword: params.get('keyword') ?? '',
-    sortBy: (params.get('sortBy') as SearchState['sortBy']) ?? 'published',
-    order: (params.get('order') as SearchState['order']) ?? 'desc',
+    sortBy: (params.get('sortBy') as BookSearchState['sortBy']) ?? 'published',
+    order: (params.get('order') as BookSearchState['order']) ?? 'desc',
     minPrice: params.get('minPrice') ? Number(params.get('minPrice')) : undefined,
     maxPrice: params.get('maxPrice') ? Number(params.get('maxPrice')) : undefined
   };
@@ -44,7 +44,7 @@ const applyQueryParam = (q: URLSearchParams, key: string, value: string | number
 export default function BooksSearchPage() {
   const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [searchState, setSearchState] = useState<SearchState>(() => makeInitialState(searchParams));
+  const [searchState, setSearchState] = useState<BookSearchState>(() => makeInitialState(searchParams));
   const [books, setBooks] = useState<BookSummary[]>([]);
   const [totalItems, setTotalItems] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
@@ -61,7 +61,7 @@ export default function BooksSearchPage() {
   };
 
   // Update search state via URL (filters, category, sort, price, page)
-  const updateSearchStateViaUrl = (updates: Partial<SearchState>) => {
+  const updateSearchStateViaUrl = (updates: Partial<BookSearchState>) => {
     setQuery(q => {
       applyQueryParam(q, 'category', updates.category);
       applyQueryParam(q, 'subcategory', updates.subcategory);
@@ -98,7 +98,7 @@ export default function BooksSearchPage() {
   };
 
   // Handler for BookFilterSidebar component filter apply
-  const handleFilterApplied = (newFilters: Partial<SearchState>) => {
+  const handleFilterApplied = (newFilters: Partial<BookSearchState>) => {
     console.log('필터 적용됨:', newFilters);
     updateSearchStateViaUrl(newFilters);
   };

--- a/src/pages/books/BooksSearchPage.tsx
+++ b/src/pages/books/BooksSearchPage.tsx
@@ -3,7 +3,7 @@ import CategoryFilterSearchBar from "../../features/books/components/CategoryFil
 import Footer from "../../components/layout/Footer";
 import BooksCategoryPopup from "../../features/books/components/BooksCategoryPopup";
 import { useEffect, useState } from "react";
-import { generatePath, useNavigate, useSearchParams } from "react-router-dom";
+import { generatePath, useLoaderData, useNavigate, useSearchParams } from "react-router-dom";
 import { SEARCH_OPTIONS, sortOptions, type BookSearchState, type BookSummary, type SearchOption } from "../../features/books/types.ts";
 import BookListItem from "../../features/books/components/BookListItem";
 import BookListHeader from "../../features/books/components/BookListHeader";
@@ -11,6 +11,7 @@ import BookFilterSidebar from "../../features/books/components/BookFilterSidebar
 import { BookService } from "../../features/books/services/BookService.ts";
 import Pagination from "../../components/navigation/Pagination.tsx";
 import { PATHS } from "../../routes/paths.ts";
+import type { BooksSearchLoaderData } from './BooksSearch.loader.ts';
 
 // Parse initial search state from URL: page, category, subcategory, minPrice, maxPrice, searchBy, keyword, sortBy, order
 function makeInitialState(params: URLSearchParams): BookSearchState {
@@ -42,14 +43,15 @@ const applyQueryParam = (q: URLSearchParams, key: string, value: string | number
 };
 
 export default function BooksSearchPage() {
+  const navigate = useNavigate();
+  
+  const { bookCategories } = useLoaderData() as BooksSearchLoaderData;
   const [isCategoryPopupOpen, setIsCategoryPopupOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchState, setSearchState] = useState<BookSearchState>(() => makeInitialState(searchParams));
   const [books, setBooks] = useState<BookSummary[]>([]);
   const [totalItems, setTotalItems] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
-
-  const navigate = useNavigate();
 
   const searchByLabel = SEARCH_OPTION_MAP[searchState.searchBy];
 
@@ -167,7 +169,10 @@ export default function BooksSearchPage() {
         />
         {isCategoryPopupOpen && (
           <div className={styles['category-popup-overlay']}>
-            <BooksCategoryPopup onClosed={handleCloseCategory} />
+            <BooksCategoryPopup
+              categories={bookCategories}
+              onClosed={handleCloseCategory}
+            />
           </div>
         )}
         <div className={styles['book-search-container']}>

--- a/src/pages/books/styles/BooksCategoryAllPage.module.css
+++ b/src/pages/books/styles/BooksCategoryAllPage.module.css
@@ -1,0 +1,12 @@
+/*
+  Mobile rules (< 1024px)
+  - Enforce min width 375px
+*/
+@media (max-width: 1023.98px) {
+
+}
+
+/* Desktop rules (≥ 1024px) */
+@media (min-width: 1024px) {
+
+}

--- a/src/pages/books/styles/BooksCategoryHomePage.module.css
+++ b/src/pages/books/styles/BooksCategoryHomePage.module.css
@@ -1,0 +1,51 @@
+.category-popup-overlay {
+  position: relative;
+}
+.book-contents-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+.best-seller-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+}
+.book-slider-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+}
+/*
+  Mobile rules (< 1024px)
+  - Enforce min width 375px
+*/
+@media (max-width: 1023.98px) {
+  .book-contents-container {
+    padding: 2px 20px;
+  }
+  .best-seller-section {
+    padding-bottom: 20px;
+  }
+}
+
+/* Desktop rules (≥ 1024px) */
+@media (min-width: 1024px) {
+  .category-popup-overlay {
+    left: 17px;
+  }
+  .book-contents-container {
+    width: 1024px;
+    padding: 20px;
+  }
+  .best-seller-section {
+    max-width: 1024px;
+    padding-bottom: 30px;
+  }
+  .book-slider-section {
+    max-width: 1024px;
+  }
+}

--- a/src/pages/books/styles/BooksCategoryPage.module.css
+++ b/src/pages/books/styles/BooksCategoryPage.module.css
@@ -1,0 +1,28 @@
+.book-category-main{
+  display: flex;
+  flex-direction: column;
+}
+.category-popup-overlay {
+  position: relative;
+}
+
+/*
+  Mobile rules (< 1024px)
+  - Enforce min width 375px
+*/
+@media (max-width: 1023.98px) {
+  .book-home-main{
+    align-self: stretch;
+  }
+}
+
+/* Desktop rules (≥ 1024px) */
+@media (min-width: 1024px) {
+  .book-category-main{
+    width: 1024px;
+    margin:0 auto;
+  }
+  .category-popup-overlay {
+    left: 17px;
+  }
+}

--- a/src/pages/books/styles/BooksCategoryPage.module.css
+++ b/src/pages/books/styles/BooksCategoryPage.module.css
@@ -5,6 +5,14 @@
 .category-popup-overlay {
   position: relative;
 }
+.book-category-title {
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  margin: 0;
+}
 
 /*
   Mobile rules (< 1024px)
@@ -13,6 +21,9 @@
 @media (max-width: 1023.98px) {
   .book-home-main{
     align-self: stretch;
+  }
+  .book-category-title {
+    padding: 15px 20px 0;
   }
 }
 
@@ -24,5 +35,8 @@
   }
   .category-popup-overlay {
     left: 17px;
+  }
+  .book-category-title {
+    padding: 15px 20px 0;
   }
 }

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -16,6 +16,7 @@ export const PATHS = {
   booksHome: "/books",
   booksSearch: "/books/search",
   bookDetails: "/books/:bookId",
+  booksCategory: "/books/category/:categoryCodeName",
 
   /* products */
   productsHome: "/products",

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -24,6 +24,9 @@ import BooksSearchPage from "../pages/books/BooksSearchPage";
 import BookDetailsPage from "../pages/books/BookDetailsPage";
 import BookDetailsDescriptionPage from "../pages/books/BookDetailsDescriptionPage";
 import BookDetailsReviewsPage from "../pages/books/BookDetailsReviewsPage";
+import BooksCategoryPage from "../pages/books/BooksCategoryPage";
+import BooksCategoryHomePage from "../pages/books/BooksCategoryHomePage";
+import BooksCategoryAllPage from "../pages/books/BooksCategoryAllPage";
 import ProductsHomePage from "../pages/products/ProductsHomePage";
 import ProductsSearchPage from "../pages/products/ProductsSearchPage";
 import ProductDetailPage from "../pages/products/ProductDetailPage";
@@ -108,6 +111,27 @@ export const router = createBrowserRouter([
                 close: { type: 'push', to: PATHS.booksHome }
               }
             }
+          },
+          { 
+            path: PATHS.booksCategory,
+            element: <BooksCategoryPage />,
+            children: [
+              {
+                index: true,
+                element: <Navigate to="home" replace />
+              },
+              {
+                path: "home",
+                element: <BooksCategoryHomePage />,
+                handle: { header: { kind: "main", title: "문앞의책방" } }
+              },
+              {
+                path: "all",
+                element: <BooksCategoryAllPage />,
+                handle: { header: { kind: "main", title: "문앞의책방" } }
+              },
+            ],
+            handle: { header: { kind: "main", title: "문앞의책방" } }
           },
           { path: PATHS.productsHome,
             element: <ProductsHomePage />,

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,7 +6,9 @@ import { faqLoader } from "../pages/customer/FAQPage.loader";
 import { productSummaryListLoader } from "../pages/products/ProductSummaryList.loader";
 import { productDetailLoader } from "../pages/products/ProductDetail.loader";
 import { booksHomeLoader } from "../pages/books/BooksHome.loader";
+import { booksSearchLoader } from "../pages/books/BooksSearch.loader";
 import { bookDetailsLoader } from "../pages/books/BookDetails.loader";
+import { booksCategoryLoader } from "../pages/books/BooksCategory.loader";
 import { NotificationPageLoader } from "../pages/customer/NotificationPage.loader";
 import { policyLoader } from "../pages/customer/PolicyPage.loader";
 
@@ -71,6 +73,7 @@ export const router = createBrowserRouter([
             element: <BooksHomePage />,
             handle: { header: { kind: "main", title: "문앞의책방" } } },
           { path: PATHS.booksSearch,
+            loader: booksSearchLoader,
             element: <BooksSearchPage />,
             handle: { header: { kind: "main", title: "문앞의책방" } } },
           { 
@@ -115,6 +118,7 @@ export const router = createBrowserRouter([
           { 
             path: PATHS.booksCategory,
             element: <BooksCategoryPage />,
+            loader: booksCategoryLoader,
             children: [
               {
                 index: true,
@@ -123,11 +127,13 @@ export const router = createBrowserRouter([
               {
                 path: "home",
                 element: <BooksCategoryHomePage />,
+                loader: booksCategoryLoader,
                 handle: { header: { kind: "main", title: "문앞의책방" } }
               },
               {
                 path: "all",
                 element: <BooksCategoryAllPage />,
+                loader: booksCategoryLoader,
                 handle: { header: { kind: "main", title: "문앞의책방" } }
               },
             ],


### PR DESCRIPTION
This patch would:
- Implement `BooksCategoryHomePage` with API integration
- Extract category fetching logic out of `BooksCategoryPopup`
- Add loaders (BooksCategory, BooksSearch)
- Update loader references after extracting `BooksCategoryPopup` fetch

